### PR TITLE
nodes method accepts String too for tag name

### DIFF
--- a/spec/iterators_spec.cr
+++ b/spec/iterators_spec.cr
@@ -103,4 +103,10 @@ describe "iterators" do
     res = div.scope.nodes(:_text).map(&.tag_text.strip).reject(&.empty?).to_a
     res.should eq %w(Bla text)
   end
+
+  it "iterator works with string tags" do
+    div = parser.nodes(:div).first
+    res = div.scope.nodes("_text").map(&.tag_text.strip).reject(&.empty?).to_a
+    res.should eq %w(Bla text)
+  end
 end

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -9,6 +9,7 @@ describe Myhtml::Node do
 
     parser.nodes(Myhtml::Lib::MyhtmlTags::MyHTML_TAG_DIV).count.should eq 2
     parser.nodes(:div).count.should eq 2
+    parser.nodes("div").count.should eq 2
     nodes = parser.nodes(Myhtml::Lib::MyhtmlTags::MyHTML_TAG_DIV).to_a
     nodes.size.should eq 2
 
@@ -55,6 +56,7 @@ describe Myhtml::Node do
     parser.parse(str)
     parser.nodes(Myhtml::Lib::MyhtmlTags::MyHTML_TAG_A).size.should eq 1
     parser.nodes(:a).size.should eq 1
+    parser.nodes("a").size.should eq 1
   end
 
   it "parse html with bom" do
@@ -81,5 +83,11 @@ describe Myhtml::Node do
         </body></html>")
       parser.free
     end
+  end
+
+  it "raise when non supported tag name is given by String" do
+    parser = Myhtml::Parser.new
+    parser.parse("<html></html>")
+    expect_raises(Myhtml::Error, /Unknown tag "xxx"/) { parser.nodes("xxx") }
   end
 end

--- a/src/myhtml/iterators.cr
+++ b/src/myhtml/iterators.cr
@@ -9,6 +9,10 @@ module Myhtml
     def nodes(tag_sym : Symbol)
       nodes(Myhtml.tag_id_by_symbol(tag_sym))
     end
+
+    def nodes(tag_str : String)
+      nodes(Myhtml.symbol_by_string!(tag_str))
+    end
   end
 
   struct RightIterator

--- a/src/myhtml/parser.cr
+++ b/src/myhtml/parser.cr
@@ -36,5 +36,9 @@ module Myhtml
     def nodes(tag_sym : Symbol)
       nodes(Myhtml.tag_id_by_symbol(tag_sym))
     end
+
+    def nodes(tag_str : String)
+      nodes(Myhtml.symbol_by_string!(tag_str))
+    end
   end
 end

--- a/src/myhtml/strings.cr
+++ b/src/myhtml/strings.cr
@@ -1,0 +1,16 @@
+require "./constants"
+
+module Myhtml
+  module StringTag
+    TAG_SYMBOL_MAP = Hash(String, Symbol).new
+    {% for name in Lib::MyhtmlTags.constants.map(&.gsub(/MyHTML_TAG_/, "").downcase) %}
+      TAG_SYMBOL_MAP["{{ name.id }}"] = :{{ name.id }}
+    {% end %}
+
+    def symbol_by_string!(str : String)
+      TAG_SYMBOL_MAP.fetch(str) { raise Error.new("Unknown tag #{str.inspect}") }
+    end
+  end
+
+  extend StringTag
+end


### PR DESCRIPTION
Adding two methods in order to accept String for node tag names

```crystal
Myhtml::Parser#nodes(tag_str : String)
Myhtml::TagsIterator#nodes(tag_str : String)
```

aimed to be called with arbitrary string by cli application like

```shell
% parse-css div foo.html
```
